### PR TITLE
msim: network mode changes (2/2)

### DIFF
--- a/media/java/android/media/CamcorderProfile.java
+++ b/media/java/android/media/CamcorderProfile.java
@@ -125,9 +125,14 @@ public class CamcorderProfile
      */
     public static final int QUALITY_HVGA = 19;
 
+    /** @hide
+     * Quality level corresponding to 1440p resolution
+     */
+    public static final int QUALITY_1440P = 20;
+
     // Start and end of quality list
     private static final int QUALITY_LIST_START = QUALITY_LOW;
-    private static final int QUALITY_LIST_END = QUALITY_HVGA;
+    private static final int QUALITY_LIST_END = QUALITY_1440P;
 
     /**
      * Time lapse quality level corresponding to the lowest available resolution.
@@ -199,9 +204,14 @@ public class CamcorderProfile
      */
     public static final int QUALITY_TIME_LAPSE_4kDCI = 1014;
 
+    /** @hide
+     * Time lapse quality level corresponding to the 1440p resolution.
+     */
+    public static final int QUALITY_TIME_LAPSE_1440P = 1015;
+
     // Start and end of timelapse quality list
     private static final int QUALITY_TIME_LAPSE_LIST_START = QUALITY_TIME_LAPSE_LOW;
-    private static final int QUALITY_TIME_LAPSE_LIST_END = QUALITY_TIME_LAPSE_4kDCI;
+    private static final int QUALITY_TIME_LAPSE_LIST_END = QUALITY_TIME_LAPSE_1440P;
 
     /**
      * High speed ( >= 100fps) quality level corresponding to the lowest available resolution.

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkControllerImpl.java
@@ -761,7 +761,7 @@ public class NetworkControllerImpl extends BroadcastReceiver
                     int start = mSubscriptionManager.getActiveSubscriptionInfoCountMax();
                     for (int i = start /* get out of normal index range */; i < start + num; i++) {
                         SubscriptionInfo info = new SubscriptionInfo(i, "", i, "", "", 0, 0, "", 0,
-                                null, 0, 0, "", 0, 0);
+                                null, 0, 0, "", 0, 0, 0);
                         subs.add(info);
                         mMobileSignalControllers.put(i, new MobileSignalController(mContext,
                                 mConfig, mHasMobileDataFeature, mPhone, mSignalsChangedCallbacks,

--- a/telephony/java/android/telephony/SubscriptionInfo.java
+++ b/telephony/java/android/telephony/SubscriptionInfo.java
@@ -120,9 +120,14 @@ public class SubscriptionInfo implements Parcelable {
     /**
      * @hide
      */
+    public int mUserNwMode;
+
+    /**
+     * @hide
+     */
     public SubscriptionInfo(int id, String iccId, int simSlotIndex, CharSequence displayName,
             CharSequence carrierName, int nameSource, int iconTint, String number, int roaming,
-            Bitmap icon, int mcc, int mnc, String countryIso, int status, int nwMode) {
+            Bitmap icon, int mcc, int mnc, String countryIso, int status, int nwMode, int userNwMode) {
         this.mId = id;
         this.mIccId = iccId;
         this.mSimSlotIndex = simSlotIndex;
@@ -137,6 +142,7 @@ public class SubscriptionInfo implements Parcelable {
         this.mMnc = mnc;
         this.mStatus = status;
         this.mNwMode = nwMode;
+        this.mUserNwMode = userNwMode;
         this.mCountryIso = countryIso;
     }
 
@@ -294,12 +300,21 @@ public class SubscriptionInfo implements Parcelable {
     public int getStatus() {
         return this.mStatus;
     }
+
     /**
      * Returns the Network mode.
      * @hide
      */
     public int getNwMode() {
         return this.mNwMode;
+    }
+
+    /**
+     * Returns the User set Network mode.
+     * @hide
+     */
+    public int getUserNwMode() {
+        return this.mUserNwMode;
     }
 
     /**
@@ -325,12 +340,13 @@ public class SubscriptionInfo implements Parcelable {
             int mnc = source.readInt();
             int status = source.readInt();
             int nwMode = source.readInt();
+            int userNwMode = source.readInt();
 
             String countryIso = source.readString();
             Bitmap iconBitmap = Bitmap.CREATOR.createFromParcel(source);
 
             return new SubscriptionInfo(id, iccId, simSlotIndex, displayName, carrierName,
-                    nameSource, iconTint, number, dataRoaming, iconBitmap, mcc, mnc, countryIso, status, nwMode);
+                    nameSource, iconTint, number, dataRoaming, iconBitmap, mcc, mnc, countryIso, status, nwMode, userNwMode);
         }
 
         @Override
@@ -354,6 +370,7 @@ public class SubscriptionInfo implements Parcelable {
         dest.writeInt(mMnc);
         dest.writeInt(mStatus);
         dest.writeInt(mNwMode);
+        dest.writeInt(mUserNwMode);
         dest.writeString(mCountryIso);
         mIconBitmap.writeToParcel(dest, flags);
     }
@@ -369,6 +386,7 @@ public class SubscriptionInfo implements Parcelable {
                 + " displayName=" + mDisplayName + " carrierName=" + mCarrierName
                 + " nameSource=" + mNameSource + " iconTint=" + mIconTint
                 + " dataRoaming=" + mDataRoaming + " iconBitmap=" + mIconBitmap + " mcc " + mMcc
-                + " mnc " + mMnc + " mSubStatus=" + mStatus + " mNwMode=" + mNwMode + "}";
+                + " mnc " + mMnc + " mSubStatus=" + mStatus + " mNwMode=" + mNwMode
+                + " mUserNwMode=" + mUserNwMode + "}";
     }
 }

--- a/telephony/java/android/telephony/SubscriptionManager.java
+++ b/telephony/java/android/telephony/SubscriptionManager.java
@@ -132,6 +132,13 @@ public class SubscriptionManager {
      */
     public static final String NETWORK_MODE = "network_mode";
 
+    /**
+     * The user configured Network mode of SIM/sub.
+     * <P>Type: INTEGER (int)</P>
+     * {@hide}
+     */
+    public static final String USER_NETWORK_MODE = "user_network_mode";
+
     /** {@hide} */
     public static final int DEFAULT_NW_MODE = -1;
 


### PR DESCRIPTION
- To track what the user set for the particular sub independent
  of the currently set network mode (i.e. PREFERRED_NETWORK_MODE)
- Useful on MSIM where the modem may only support 2G on one of the slots,
  so the preferred network mode (and the NETWORK_MODE column) would
  not always reflect the user desired network mode.

Ref: CYNGNOS-291

Change-Id: Ic6cc66d3dc2277f920785679c7fcc6e3c7581570
